### PR TITLE
Shifting commonAPI URL properties to common_ci from application.properties

### DIFF
--- a/src/main/environment/common_ci.properties
+++ b/src/main/environment/common_ci.properties
@@ -2,7 +2,10 @@ spring.datasource.url=@env.DATABASE_URL@
 spring.datasource.username=@env.DATABASE_USERNAME@
 spring.datasource.password=@env.DATABASE_PASSWORD@
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-common-api-url=@env.COMMON_API@
+
+common-api-url-searchuserbyid=@env.COMMON_API@beneficiary/searchUserByID
+common-api-url-searchBeneficiary=@env.COMMON_API@beneficiary/searchBeneficiary
+
 callcentre-server-ip=@env.CALLCENTRE_SERVER_IP@
 ### Redis IP
 spring.data.redis.host=localhost

--- a/src/main/environment/common_example.properties
+++ b/src/main/environment/common_example.properties
@@ -8,6 +8,10 @@ spring.profiles.active=test
 callcentre-server-ip=10.208.122.99
 common-api-url=http://localhost:8083/
 
+
+common-api-url-searchuserbyid=http://localhost:8083/beneficiary/searchUserByID
+common-api-url-searchBeneficiary=http://localhost:8083/beneficiary/searchBeneficiary
+
 ### Redis IP
 spring.data.redis.host=localhost
 jwt.secret=my-32-character-ultra-secure-and-ultra-long-secret

--- a/src/main/java/com/iemr/inventory/service/visit/VisitServiceImpl.java
+++ b/src/main/java/com/iemr/inventory/service/visit/VisitServiceImpl.java
@@ -65,8 +65,7 @@ public class VisitServiceImpl implements VisitService {
 	Logger logger = LoggerFactory.getLogger(this.getClass().getName());
 	private static HttpUtils httpUtils = new HttpUtils();
 	private InputMapper inputMapper = new InputMapper();
-	private String identityBaseURL = ConfigProperties.getPropertyByName("common-api-url");
-	private static final String COMMON_BASE_URL = "COMMON_BASE_URL";
+
 
 	@Override
 	public BeneficiaryModel getVisitDetail(String benrID, Integer providerservicemapID, String auth) throws Exception {
@@ -144,8 +143,7 @@ public class VisitServiceImpl implements VisitService {
 		String jwtTokenFromCookie = cookieUtil.getJwtTokenFromCookie(requestHeader);
 		header.put("Cookie", "Jwttoken=" + jwtTokenFromCookie);
 
-		result = httpUtils.post(ConfigProperties.getPropertyByName("common-api-url-searchBeneficiary")
-				.replace(COMMON_BASE_URL, identityBaseURL), benrID, header);
+		result = httpUtils.post(ConfigProperties.getPropertyByName("common-api-url-searchBeneficiary"), benrID, header);
 		OutputResponse identityResponse = inputMapper.gson().fromJson(result, OutputResponse.class);
 		if (identityResponse.getStatusCode() == OutputResponse.USERID_FAILURE) {
 			throw new IEMRException(identityResponse.getErrorMessage());

--- a/src/main/java/com/iemr/inventory/service/visit/VisitServiceImpl.java
+++ b/src/main/java/com/iemr/inventory/service/visit/VisitServiceImpl.java
@@ -109,8 +109,7 @@ public class VisitServiceImpl implements VisitService {
 		String jwtTokenFromCookie = cookieUtil.getJwtTokenFromCookie(requestHeader);
 		header.put("Cookie", "Jwttoken=" + jwtTokenFromCookie);
 
-		result = httpUtils.post(ConfigProperties.getPropertyByName("common-api-url-searchuserbyid")
-				.replace(COMMON_BASE_URL, identityBaseURL), benrID, header);
+		result = httpUtils.post(ConfigProperties.getPropertyByName("common-api-url-searchuserbyid"), benrID, header);
 		OutputResponse identityResponse = inputMapper.gson().fromJson(result, OutputResponse.class);
 		if (identityResponse.getStatusCode() != 200) {
 			throw new InventoryException("Invalid BeneficiaryID");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,8 +23,7 @@ logging.level.com.iemr=DEBUG
 
 spring.jpa.show-sql=true
 enableCTIUserCreation=true
-common-api-url-searchuserbyid=COMMON_BASE_URLbeneficiary/searchUserByID
-common-api-url-searchBeneficiary=COMMON_BASE_URLbeneficiary/searchBeneficiary
+
 
 spring.main.allow-bean-definition-overriding=true
 


### PR DESCRIPTION
## 📋 Description

JIRA ID: 1602

Please provide a summary of the change and the motivation behind it. Include relevant context and details.
Since previous changes of using placholders in the common API URLs did not work, we need to shift the common API URL properties to common_ci.properties from application.properties.
---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated configuration properties to use more specific API URLs for user and beneficiary searches.
  - Simplified URL handling by removing placeholder substitutions in configuration.
  - Cleaned up unused property entries related to beneficiary search in the configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->