### PR TITLE
Fix for date parsing issue for LastModDate, CreatedDate

### DIFF
--- a/src/main/java/com/iemr/inventory/controller/visit/VisitController.java
+++ b/src/main/java/com/iemr/inventory/controller/visit/VisitController.java
@@ -67,16 +67,9 @@ public class VisitController {
 			BeneficiaryModel saveData = visitService.getVisitDetail(beneficiaryIDStr,
 					benVisitDetail.getProviderServiceMapID(), auth);
 
-	        String beneficiaryIDStr = benVisitDetail.getBeneficiaryID();
 	        if (beneficiaryIDStr == null || beneficiaryIDStr.trim().isEmpty()) {
 	            throw new IllegalArgumentException("Beneficiary ID cannot be null or empty");
 	        }
-
-	        BeneficiaryModel saveData = visitService.getVisitDetail(
-	            beneficiaryIDStr,
-	            benVisitDetail.getProviderServiceMapID(),
-	            auth
-	        );
 
 	        response.setResponse(saveData.toString());
 

--- a/src/main/java/com/iemr/inventory/data/visit/BenVisitDetail.java
+++ b/src/main/java/com/iemr/inventory/data/visit/BenVisitDetail.java
@@ -34,6 +34,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.LongSerializationPolicy;
 import com.google.gson.annotations.Expose;
+import com.iemr.inventory.to.provider.JsonUtils;
 import com.iemr.inventory.utils.mapper.OutputMapper;
 
 import lombok.Data;
@@ -173,16 +174,7 @@ public class BenVisitDetail {
 	
 	@Override
 	public String toString() {
-		Gson gson = new GsonBuilder()
-	.excludeFieldsWithoutExposeAnnotation()
-	.setLongSerializationPolicy(LongSerializationPolicy.STRING)
-	.serializeNulls()
-	.setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") // format dates without custom adapter
-	.create();
-
-	return gson.toJson(this);
-
-	
+		return JsonUtils.GSON.toJson(this);	
 	}
 
 }

--- a/src/main/java/com/iemr/inventory/data/visit/BenVisitDetail.java
+++ b/src/main/java/com/iemr/inventory/data/visit/BenVisitDetail.java
@@ -30,6 +30,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.LongSerializationPolicy;
 import com.google.gson.annotations.Expose;
 import com.iemr.inventory.utils.mapper.OutputMapper;
 
@@ -167,10 +170,19 @@ public class BenVisitDetail {
 	
 	@Transient
 	private OutputMapper outputMapper = new OutputMapper();
-
+	
 	@Override
 	public String toString() {
-		return outputMapper.gson().toJson(this);
+		Gson gson = new GsonBuilder()
+	.excludeFieldsWithoutExposeAnnotation()
+	.setLongSerializationPolicy(LongSerializationPolicy.STRING)
+	.serializeNulls()
+	.setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") // format dates without custom adapter
+	.create();
+
+	return gson.toJson(this);
+
+	
 	}
 
 }

--- a/src/main/java/com/iemr/inventory/data/visit/BenVisitDetail.java
+++ b/src/main/java/com/iemr/inventory/data/visit/BenVisitDetail.java
@@ -30,9 +30,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.LongSerializationPolicy;
 import com.google.gson.annotations.Expose;
 import com.iemr.inventory.to.provider.JsonUtils;
 import com.iemr.inventory.utils.mapper.OutputMapper;

--- a/src/main/java/com/iemr/inventory/data/visit/BeneficiaryModel.java
+++ b/src/main/java/com/iemr/inventory/data/visit/BeneficiaryModel.java
@@ -31,6 +31,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.LongSerializationPolicy;
 import com.google.gson.annotations.Expose;
+import com.iemr.inventory.to.provider.JsonUtils;
 import com.iemr.inventory.utils.mapper.OutputMapper;
 
 import lombok.Data;
@@ -179,15 +180,7 @@ public class BeneficiaryModel {
 
 	@Override
 	public String toString() {
-		Gson gson = new GsonBuilder()
-	.excludeFieldsWithoutExposeAnnotation()
-	.setLongSerializationPolicy(LongSerializationPolicy.STRING)
-	.serializeNulls()
-	.setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") // format dates without custom adapter
-	.create();
-
-	return gson.toJson(this);
-
+		return JsonUtils.GSON.toJson(this);
 	
 	}
 	

--- a/src/main/java/com/iemr/inventory/data/visit/BeneficiaryModel.java
+++ b/src/main/java/com/iemr/inventory/data/visit/BeneficiaryModel.java
@@ -27,9 +27,6 @@ import java.util.List;
 import jakarta.persistence.Transient;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.LongSerializationPolicy;
 import com.google.gson.annotations.Expose;
 import com.iemr.inventory.to.provider.JsonUtils;
 import com.iemr.inventory.utils.mapper.OutputMapper;

--- a/src/main/java/com/iemr/inventory/data/visit/BeneficiaryModel.java
+++ b/src/main/java/com/iemr/inventory/data/visit/BeneficiaryModel.java
@@ -25,7 +25,6 @@ import java.sql.Timestamp;
 import java.util.List;
 
 import jakarta.persistence.Transient;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.google.gson.annotations.Expose;
 import com.iemr.inventory.to.provider.JsonUtils;

--- a/src/main/java/com/iemr/inventory/data/visit/BeneficiaryModel.java
+++ b/src/main/java/com/iemr/inventory/data/visit/BeneficiaryModel.java
@@ -27,6 +27,9 @@ import java.util.List;
 import jakarta.persistence.Transient;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.LongSerializationPolicy;
 import com.google.gson.annotations.Expose;
 import com.iemr.inventory.utils.mapper.OutputMapper;
 
@@ -176,7 +179,16 @@ public class BeneficiaryModel {
 
 	@Override
 	public String toString() {
-		return outputMapper.gson().toJson(this);
+		Gson gson = new GsonBuilder()
+	.excludeFieldsWithoutExposeAnnotation()
+	.setLongSerializationPolicy(LongSerializationPolicy.STRING)
+	.serializeNulls()
+	.setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") // format dates without custom adapter
+	.create();
+
+	return gson.toJson(this);
+
+	
 	}
 	
 }

--- a/src/main/java/com/iemr/inventory/to/provider/JsonUtils.java
+++ b/src/main/java/com/iemr/inventory/to/provider/JsonUtils.java
@@ -1,0 +1,14 @@
+package com.iemr.inventory.to.provider;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.LongSerializationPolicy;
+
+public class JsonUtils {
+	 public static final Gson GSON = new GsonBuilder()
+		        .excludeFieldsWithoutExposeAnnotation()
+		        .setLongSerializationPolicy(LongSerializationPolicy.STRING)
+		        .serializeNulls()
+		        .setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+		        .create();
+}


### PR DESCRIPTION
## 📋 Description

JIRA ID: 1602

Please provide a summary of the change and the motivation behind it. Include relevant context and details.
The toString() method is changed to configure Gson to serialise date as a proper serialised ISO formatted date string instead of a raw numeric timestamp. This ensures compatability with JSON parsers preventing date parsing errors. 
---

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced JSON serialization for visit and beneficiary details to ensure consistent formatting, including null values and standardized date representation.  
  - Introduced centralized JSON utility for improved and uniform data display across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->